### PR TITLE
Release 26.29.2

### DIFF
--- a/netdaemon_6/config.json
+++ b/netdaemon_6/config.json
@@ -1,6 +1,6 @@
 {
   "name": "NetDaemon V6 (.NET 10)",
-  "version": "26.29.0",
+  "version": "26.29.2",
   "slug": "netdaemon6",
   "description": "NetDaemon V6 (.NET 10), Write automations in C# for Home Assistant",
   "url": "https://netdaemon.xyz",


### PR DESCRIPTION
Updates the Home Assistant add-on NetDaemon version to 26.29.2.